### PR TITLE
Add guard so plugin only executes once per vim session

### DIFF
--- a/plugin/autocorrect.vim
+++ b/plugin/autocorrect.vim
@@ -1,11 +1,11 @@
 
-let g:auto_correct_loaded=0
+let s:auto_correct_loaded=0
 
 function! AutoCorrect()
-    if exists('g:autocorrect_loaded')
+    if exists('s:autocorrect_loaded')
         return
     else
-        let g:autocorrect_loaded='1'
+        let s:autocorrect_loaded='1'
     endif
 ia Bernouilli Bernoulli
 ia bernouilli Bernoulli

--- a/plugin/autocorrect.vim
+++ b/plugin/autocorrect.vim
@@ -1,4 +1,12 @@
+
+let g:auto_correct_loaded=0
+
 function! AutoCorrect()
+    if exists('g:autocorrect_loaded')
+        return
+    else
+        let g:autocorrect_loaded='1'
+    endif
 ia Bernouilli Bernoulli
 ia bernouilli Bernoulli
 ia BErnouilli Bernoulli


### PR DESCRIPTION
By including this guard, you can include the plugin every time you open a file type, but only pay the execution time once. E.g.

```
autocmd BufEnter *md :exe ":call AutoCorrect()"                                                                                
```

Tested manually